### PR TITLE
fix(openark-kiss): load child cluster ansible defaults

### DIFF
--- a/apps/openark-kiss/templates/workload-template-kubespray.yaml
+++ b/apps/openark-kiss/templates/workload-template-kubespray.yaml
@@ -188,6 +188,8 @@ spec:
           - --inventory
           - /root/inventory/default/all.yaml
           - --inventory
+          - /root/inventory/cluster/defaults.yaml
+          - --inventory
           - /root/inventory/cluster/config.yaml
           - --inventory
           - /root/inventory/cluster/hosts.yaml

--- a/crates/openark-kiss-ansible/src/lib.rs
+++ b/crates/openark-kiss-ansible/src/lib.rs
@@ -196,6 +196,8 @@ impl AnsibleClient {
                             "--inventory".into(),
                             "/root/ansible/defaults/all.yaml".into(),
                             "--inventory".into(),
+                            "/root/ansible/defaults.yaml".into(),
+                            "--inventory".into(),
                             "/root/ansible/config.yaml".into(),
                             "--inventory".into(),
                             "/root/ansible/hosts.yaml".into(),


### PR DESCRIPTION
## Summary

Load the per-child `defaults.yaml` generated from `cluster.children[].ansible` in both OpenARK KISS Kubespray execution paths.

## Root cause

The child ConfigMap is mounted correctly, but its `defaults.yaml` is not passed to `ansible-playbook` as an inventory source. As a result, values such as `kube_child_pods_subnet` remain at the shared default instead of using the child-specific value.

## Changes

- Operator Jobs load `/root/ansible/defaults.yaml`.
- Argo Workflow loads `/root/inventory/cluster/defaults.yaml`.
- Both load child defaults after shared defaults and before runtime `config.yaml` and `hosts.yaml`.
- Preserve the existing child ConfigMap key and Values contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p openark-kiss-ansible --features std`
- `cargo test -p openark-kiss-ansible --features std --lib`
- `helm lint apps/openark-kiss -f values.yaml`
- Rendered the WorkflowTemplate and verified the child defaults inventory order.
- Rendered a sample DataX child and verified `ansible-control-planes-datax` still exposes `defaults.yaml`.

## Rollout note

The Operator path requires a rebuilt OpenARK image and deployment before live child-cluster provisioning can validate the fix.

Related: SmartX-Team/mobilex-k8s#6
